### PR TITLE
This fixes #18 — missing headers for dependent requests

### DIFF
--- a/lib/batch-request.js
+++ b/lib/batch-request.js
@@ -40,36 +40,41 @@ var batchRequest = function(params) {
 
         var requests = req.body;
 
+        var requestPromise = function(r) {
+            r.headers = r.headers || {};
+
+            r.url = getFinalUrl(req, r);
+
+            _.each(params.defaultHeaders, function(headerV, headerK) {
+                if (!(headerK in r.headers)) { // copy defaults if not already exposed
+                    r.headers[headerK] = headerV;
+                }
+            });
+            _.each(params.forwardHeaders, function(headerK) {
+                if (!(headerK in r.headers) && headerK in req.headers) { // copy forward if not already exposed
+                    var forwardValue = req.headers[headerK];
+                    r.headers[headerK] = forwardValue;
+                }
+            });
+            return request(r).spread(function(response, body) {
+                return {
+                    'statusCode': response.statusCode,
+                    'body': body,
+                    'headers': response.headers
+                };
+            });
+        };
+
         // First, let's fire off all calls without any dependencies, accumulate their promises
         var requestPromises = _.reduce(requests, function(promises, r, key) {
             if (!r.dependency || r.dependency === 'none') {
-                r.headers = r.headers || {};
-
-                r.url = getFinalUrl(req, r);
-
-                _.each(params.defaultHeaders, function(headerV, headerK) {
-                    if (!(headerK in r.headers)) { // copy defaults if not already exposed
-                        r.headers[headerK] = headerV;
-                    }
-                });
-                _.each(params.forwardHeaders, function(headerK) {
-                    if (!(headerK in r.headers) && headerK in req.headers) { // copy forward if not already exposed
-                        var forwardValue = req.headers[headerK];
-                        r.headers[headerK] = forwardValue;
-                    }
-                });
-                promises[key] = request(r).spread(function(response, body) {
-                    return {
-                        'statusCode': response.statusCode,
-                        'body': body,
-                        'headers': response.headers
-                    };
-                });
+                promises[key] = requestPromise(r);
             }
             // And while we do that, build the dependency object with those items as keys
             // { key: Promise }
             return promises;
         }, {});
+
 
         // Then recursively iterate over all items with dependencies, resolving some at each pass
         var recurseDependencies = function (reqs) {
@@ -86,9 +91,7 @@ var batchRequest = function(params) {
                     });
                     if (dependent) {
                         requestPromises[dependentKey] = rp.then(function() {
-                            return request(dependent);
-                        }).spread(function(response, body) {
-                            return response;
+                            return requestPromise(dependent);
                         });
                     }
                 });

--- a/package.json
+++ b/package.json
@@ -34,5 +34,6 @@
     "request",
     "http",
     "utility"
-  ]
+  ],
+  "license": "ISC"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "batch-request",
   "description": "Batch Request - Utility library to enable a server to handle batch requests",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "Victor Quinn <mail@victorquinn.com>",
   "homepage": "http://batch-request.socialradar.com",
   "repository": "https://github.com/socialradar/batch-request",


### PR DESCRIPTION
Please review. Basically amounts to pulling the header-setting function up a level and referencing that for both non-dependent and dependent requests.

I also added a test, which failed before making the changes and that now passed. @victorquinn 