### PR TITLE
Added option for inheriting headers.

### DIFF
--- a/lib/batch-request.js
+++ b/lib/batch-request.js
@@ -30,6 +30,8 @@ function getFinalUrl(req, r) {
 
 var batchRequest = function(params) {
 
+    var ignoredHeadersRegex = /^Content-*/i;
+
     // Set default option values
     params = params || {};
     params.localOnly = (typeof params.localOnly === 'undefined') ? true : params.localOnly;
@@ -39,6 +41,7 @@ var batchRequest = function(params) {
     params.allowedHosts = (typeof params.allowedHosts === 'undefined') ? null : params.allowedHosts;
     params.defaultHeaders = (typeof params.defaultHeaders === 'undefined') ? {} : params.defaultHeaders;
     params.forwardHeaders = (typeof params.forwardHeaders === 'undefined') ? [] : params.forwardHeaders;
+    params.inheritHeaders = !!params.inheritHeaders;
 
     var batch = function(req, res, next) {
         // Here we assume the request has already been validated, either by
@@ -55,17 +58,29 @@ var batchRequest = function(params) {
 
             r.url = getFinalUrl(req, r);
 
+            if(params.inheritHeaders) {
+                _.each(req.headers, function(header, headerName) {
+                    if(ignoredHeadersRegex.test(headerName) || headerName in r.headers) {
+                        return;
+                    }
+
+                    r.headers[headerName] = header;
+                });
+            }
+
             _.each(params.defaultHeaders, function(headerV, headerK) {
                 if (!(headerK in r.headers)) { // copy defaults if not already exposed
                     r.headers[headerK] = headerV;
                 }
             });
+
             _.each(params.forwardHeaders, function(headerK) {
                 if (!(headerK in r.headers) && headerK in req.headers) { // copy forward if not already exposed
                     var forwardValue = req.headers[headerK];
                     r.headers[headerK] = forwardValue;
                 }
             });
+
             return request(r)
                 .then(function(response) {
                     var body = response.body;
@@ -194,7 +209,7 @@ var batchRequest = function(params) {
 
         // Wait for all to complete before responding
         Promise.props(requestPromises).then(function(result) {
-            
+
             // remove all properties, except status, body, and headers
             var output = {};
             for(var prop in result){

--- a/test/helpers/app.js
+++ b/test/helpers/app.js
@@ -80,6 +80,10 @@ function getApp(options) {
         }, 250);
     });
 
+    app.get('/header/bounce', function(req, res) {
+        return res.status(200).json(req.headers);
+    });
+
     app.get('/header/:name', function(req, res) {
         if ((req.params.name in req.headers)) {
             res.json({


### PR DESCRIPTION
As discussed in Issue #22, adds the `inheritHeaders` option.  If provided and truthy, `inheritHeaders` copies headers from the batch request to the individual requests, excluding headers that start with "Content-" (e.g. "Content-Length").  This allows some headers, such as `HTTPOnly` Cookies to be shared with the individual requests.

This PR includes 6 new tests to test this functionality.